### PR TITLE
Latest changes 

### DIFF
--- a/ByolSetup.ps1
+++ b/ByolSetup.ps1
@@ -44,6 +44,7 @@ Prefix for security group names. Security groups will be named SecurityGroupName
 
 .PARAMETER Path
 Optional: Folder under the container that needs to be used as mount point. If not given, container will be used as the mount point.
+Note: This is not supported at this point.
 
 .PARAMETER ReaderSecurityGroupId
 Optional: Id of the reader security group.


### PR DESCRIPTION
The changes include:
1. Removed the container name parameter since CI defaults the container to customerinsights.
2. Create customerinsights container if it doesn't exist in the storage account.
3. Add storage blob data owner role for the current user if it doesn't exist.